### PR TITLE
fix: corrected the strictSSL setting for the jira client

### DIFF
--- a/src/jira.test.ts
+++ b/src/jira.test.ts
@@ -19,7 +19,7 @@ function createTestInstance(actualOptions: Partial<JiraApiOptions> = {}) {
   if ("axios" in actualOptions) {
     finalOptions.axios = actualOptions.axios;
   } else {
-    finalOptions.strictSSL = finalOptions.strictSSL ?? true;
+    finalOptions.strictSSL = actualOptions.strictSSL ?? true;
     finalOptions.ca = finalOptions.ca ?? undefined;
   }
 
@@ -75,7 +75,21 @@ describe("Jira API Tests", () => {
         strictSSL: false,
       });
 
-      expect(jira.httpsAgent).toBeDefined();
+      expect(jira.httpsAgent.options.rejectUnauthorized).toBe(false);
+    });
+
+    it("Constructor with ssl default empty", () => {
+      const { jira } = createTestInstance({});
+
+      expect(jira.httpsAgent.options.rejectUnauthorized).toBe(true);
+    });
+
+    it("Constructor with with ssl checking enabled", () => {
+      const { jira } = createTestInstance({
+        strictSSL: true,
+      });
+
+      expect(jira.httpsAgent.options.rejectUnauthorized).toBe(true);
     });
 
     it("should allow the user to pass in a certificate authority", () => {

--- a/src/jira.ts
+++ b/src/jira.ts
@@ -78,7 +78,7 @@ export class JiraApi {
     if ("axios" in options) {
       this.axios = options.axios;
     } else if ("strictSSL" in options || "ca" in options) {
-      this.httpsAgent = new Agent({ rejectUnauthorized: !options.strictSSL, ca: options.ca });
+      this.httpsAgent = new Agent({ rejectUnauthorized: options.strictSSL ?? true, ca: options.ca });
       this.axios = axios.create({
         httpsAgent: this.httpsAgent,
       });


### PR DESCRIPTION
I have found a bug when working in development mode for a real Jira client.

I use ngrok to create https for my node backend. When using your library, I pass strictSSL in the client settings:

```typescript
 this.jiraRestApi = new JiraApi({
        protocol: 'https',
        host: jiraHost,
        username: jiraUsername,
        password: jiraPassword,
        apiVersion: 2,
        timeout: 5000,
        strictSSL: false,
});
```
As a result, when a POST request is sent, the request fails with errors.

```typescript
cause: Error: unable to verify the first certificate
      at TLSSocket.onConnectSecure (node:_tls_wrap:1674:34)
      at TLSSocket.emit (node:events:518:28)
      at TLSSocket._finishInit (node:_tls_wrap:1085:8)
      at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:871:12) {
    code: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
  }
```

When using the [classic Jira client](https://www.npmjs.com/package/jira-client), there was no such problem, so I started looking at the sources and discovered the difference

```typescript
//  Extract from the original client where strictSSL is added
makeRequestHeader(uri, options = {}) {
    return {
      rejectUnauthorized: this.strictSSL,
      method: options.method || 'GET',
      uri,
      json: true,
      ...options
    };
  }
```

```typescript
// Your code snippet
 else if ("strictSSL" in options || "ca" in options) {
            this.httpsAgent = new https_1.Agent({ rejectUnauthorized: !options.strictSSL, ca: options.ca });
            this.axios = axios_1.default.create({
                httpsAgent: this.httpsAgent,
            });
        }
```

Apparently the bug was in a wrong negation(`!options.strictSSL`), and there was also a bug in the tests that failed to check this script.

```typescript
this.jiraRestApi = new JiraApi({
        protocol: 'https',
        host: jiraHost,
        username: jiraUsername,
        password: jiraPassword,
        apiVersion: 2,
        timeout: 5000,
        strictSSL: false,
      });
      console.log(this.jiraRestApi.axios.defaults?.httpsAgent.options); //  strictSSL is true
```

It turns out that when strictSSL is disabled, on the contrary, it is enabled.
Fixed this behaviour and added tests.

